### PR TITLE
Fix unsafe divergence expression evaluation

### DIFF
--- a/freecad/optics_design_workbench/freecad_elements/numeric_expression.py
+++ b/freecad/optics_design_workbench/freecad_elements/numeric_expression.py
@@ -1,0 +1,66 @@
+__license__ = 'LGPL-3.0-or-later'
+__copyright__ = 'Copyright 2026  W. Braun (epiray GmbH)'
+__authors__ = 'P. Bredol'
+__url__ = 'https://github.com/zaphB/freecad.optics_design_workbench'
+
+import ast
+import math
+import operator
+
+
+_CONSTANTS = {
+  'e': math.e,
+  'inf': math.inf,
+  'pi': math.pi,
+}
+
+_BINARY_OPERATORS = {
+  ast.Add: operator.add,
+  ast.Sub: operator.sub,
+  ast.Mult: operator.mul,
+  ast.Div: operator.truediv,
+  ast.Pow: operator.pow,
+}
+
+_UNARY_OPERATORS = {
+  ast.UAdd: operator.pos,
+  ast.USub: operator.neg,
+}
+
+
+def parseNumericExpression(expression):
+  '''Parse a scalar numeric expression without executing arbitrary code.'''
+  if not isinstance(expression, str):
+    raise ValueError('numeric expression must be a string')
+  if len(expression) > 256:
+    raise ValueError('numeric expression is too long')
+
+  try:
+    parsed = ast.parse(expression, mode='eval')
+  except SyntaxError as exc:
+    raise ValueError(f'invalid numeric expression: {expression!r}') from exc
+
+  if sum(1 for _ in ast.walk(parsed)) > 64:
+    raise ValueError('numeric expression is too complex')
+
+  return float(_evaluateNode(parsed.body))
+
+
+def _evaluateNode(node):
+  if isinstance(node, ast.Constant):
+    if isinstance(node.value, bool) or not isinstance(node.value, (int, float)):
+      raise ValueError('numeric expression contains a non-numeric literal')
+    return float(node.value)
+
+  if isinstance(node, ast.Name) and node.id in _CONSTANTS:
+    return _CONSTANTS[node.id]
+
+  if isinstance(node, ast.BinOp) and type(node.op) in _BINARY_OPERATORS:
+    operation = _BINARY_OPERATORS[type(node.op)]
+    return operation(_evaluateNode(node.left), _evaluateNode(node.right))
+
+  if isinstance(node, ast.UnaryOp) and type(node.op) in _UNARY_OPERATORS:
+    operation = _UNARY_OPERATORS[type(node.op)]
+    return operation(_evaluateNode(node.operand))
+
+  raise ValueError(f'unsupported numeric expression element: {node.__class__.__name__}')

--- a/freecad/optics_design_workbench/freecad_elements/point_source.py
+++ b/freecad/optics_design_workbench/freecad_elements/point_source.py
@@ -24,6 +24,7 @@ from .. import io
 
 from .generic_source import *
 from .common import *
+from .numeric_expression import parseNumericExpression
 from ..simulation.raytracing_cache import *
 
 #####################################################################################################
@@ -234,7 +235,7 @@ class PointSourceProxy(GenericSourceProxy):
               else:
                 if (prevDivergence is None 
                       or prevDivergence == '-' 
-                      or not isclose(float(eval(prevDivergence)), divergenceAngle) ):
+                      or not isclose(parseNumericExpression(prevDivergence), divergenceAngle) ):
                   setattr(obj, 'Divergence', f'{-sign(f)*divergenceAngle/pi:.6g}*pi')
             else:
               setattr(obj, 'Divergence', '-')
@@ -244,7 +245,7 @@ class PointSourceProxy(GenericSourceProxy):
       if prop == 'Divergence':
         divergence = getattr(obj, 'Divergence', None)
         if divergence is not None and divergence != '-':
-          newDivergenceAngle = float(eval(divergence))
+          newDivergenceAngle = parseNumericExpression(divergence)
 
         # try to find 1/e radius of power density
         f = getattr(obj, 'FocalLength', None)

--- a/test/00-pure-python/test_numeric_expression.py
+++ b/test/00-pure-python/test_numeric_expression.py
@@ -1,0 +1,38 @@
+__license__ = 'LGPL-3.0-or-later'
+__copyright__ = 'Copyright 2026  W. Braun (epiray GmbH)'
+__authors__ = 'P. Bredol'
+__url__ = 'https://github.com/zaphB/freecad.optics_design_workbench'
+
+import math
+import pathlib
+import sys
+
+import pytest
+
+
+sys.path.insert(0, str(pathlib.Path(__file__).parents[2]
+                                  / 'freecad'
+                                  / 'optics_design_workbench'
+                                  / 'freecad_elements'))
+
+from numeric_expression import parseNumericExpression
+
+
+@pytest.mark.parametrize(('expression', 'expected'), [
+  ('0', 0),
+  ('0.07*pi', 0.07*math.pi),
+  ('-pi/2 + 1e-3', -math.pi/2 + 1e-3),
+  ('inf', math.inf),
+])
+def test_parses_numeric_expressions_used_by_freecad_documents(expression, expected):
+  assert parseNumericExpression(expression) == pytest.approx(expected)
+
+
+def test_rejects_code_execution(tmp_path):
+  target = tmp_path / 'executed'
+
+  with pytest.raises(ValueError):
+    parseNumericExpression(
+      f'__import__("pathlib").Path("{target}").write_text("executed")')
+
+  assert not target.exists()


### PR DESCRIPTION
Fixes #51.

Replaces both unsafe divergence `eval()` calls with an allowlisted numeric
expression parser. Existing arithmetic and the `pi`, `e`, and `inf` constants
remain supported; executable expressions are rejected.

Validated with the parser tests, FreeCAD workbench import tests, 52 FCStd
document/property cases, and a direct malicious-payload check.
